### PR TITLE
Add TYPO3 v11 in the possible versions for typo3/cms-core requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "typo3/cms-core": "^10.4.0"
+        "typo3/cms-core": "^10.4.0|^11.5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Permit use of the plugin in TYPO3 v11.
All seam to work fine as-is.

Probably tag 1.1.0 ?