### PR TITLE
#2 - fix li rendering

### DIFF
--- a/Classes/ViewHelpers/NoteBasPage/ProcessViewHelper.php
+++ b/Classes/ViewHelpers/NoteBasPage/ProcessViewHelper.php
@@ -18,7 +18,7 @@ class ProcessViewHelper extends AbstractViewHelper
 
     public function initializeArguments()
     {
-        $this->registerArgument('noteBasTableau', 'bool', 'Si les notes de bas de tableau sont affiché sous leur tableaux respectifs', false);
+        $this->registerArgument('noteBasTableau', 'bool', 'Si les notes de bas de tableau sont affichées sous leur tableaux respectifs', false);
     }
 
     /**
@@ -70,6 +70,7 @@ class ProcessViewHelper extends AbstractViewHelper
         }
 
         $pattern = '/\<footquote content=\"([^"]*)\"\>(.*?)<\/footquote\>/im';
+        $content = html_entity_decode($content);
         preg_match_all($pattern, $content, $matchesFootquote);
 
         /** @var NoteBasPageRepository $noteBasPageRepository */


### PR DESCRIPTION
2 corrections :
- une correction de faute d’orthographe dans le texte d’aide du viewHelper ;
- la correction mise en place dans québec.ca pour faire fonctionner les notes de bas de page dans les listes.

cf copie d’écran du bug #2 après application du correctif.
<img width="151" alt="image" src="https://user-images.githubusercontent.com/64539039/201501214-15ecb16c-6cde-4f7b-b1f8-23384aac2fe1.png">
