### PR TITLE
Allow footquote tag in ul tag

### DIFF
--- a/Classes/ViewHelpers/NoteBasPage/ProcessViewHelper.php
+++ b/Classes/ViewHelpers/NoteBasPage/ProcessViewHelper.php
@@ -70,7 +70,6 @@ class ProcessViewHelper extends AbstractViewHelper
         }
 
         $pattern = '/\<footquote content=\"([^"]*)\"\>(.*?)<\/footquote\>/im';
-        $content = html_entity_decode($content);
         preg_match_all($pattern, $content, $matchesFootquote);
 
         /** @var NoteBasPageRepository $noteBasPageRepository */

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -5,4 +5,6 @@ plugin.tx_lbofootnote {
     }
 }
 
+#Allow footnote tag in ul tag
+lib.parseFunc.allowTags := addToList(footquote)
 lib.parseFunc_RTE.allowTags := addToList(footquote)

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -3,16 +3,16 @@
     <file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2021-06-23T11:36:30Z">
         <body>
              <trans-unit id="note_bas_page.link_accessibility" xml:space="preserve" approved="yes">
-                <target state="translated">>Lire le contenu de la note numéro </target>
+                <target state="translated">Lire le contenu de la note numéro </target>
              </trans-unit>
              <trans-unit id="note_bas_page.list_accessibility_title" xml:space="preserve" approved="yes">
-                <target state="translated">>Note de bas de page numéro </target>
+                <target state="translated">Note de bas de page numéro </target>
              </trans-unit>
              <trans-unit id="note_bas_page.list_accessibility_link" xml:space="preserve" approved="yes">
-                <target state="translated">>Retour à la référence de la note numéro </target>
+                <target state="translated">Retour à la référence de la note numéro </target>
              </trans-unit>
              <trans-unit id="note_bas_page.close_mobile_note" xml:space="preserve" approved="yes">
-                <target state="translated">>Fermer la note de bas de page</target>
+                <target state="translated">Fermer la note de bas de page</target>
              </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Templates/DisplayNotes.html
+++ b/Resources/Private/Templates/DisplayNotes.html
@@ -8,7 +8,7 @@
                     {index}
                 </div>
                 <div class="d-flex flex-row-reverse">
-                    <span><f:format.raw>{note}</f:format.raw></span>
+                    <span><f:format.html parseFuncTSPath="lib.parseFunc">{note}</f:format.html></span>
                     <span>
                         <a href="#link-note-{prefix}{index}">
                             <span class="visuallyHidden"><f:translate key="note_bas_page.list_accessibility_link"/></span>


### PR DESCRIPTION
On avait un problème dès que c'était dans une balise LI, on s'est rendu compte que c'était dans le parsefunc. On l'a modifié dans le typoscript. On a aussi retiré la ligne maintenant inutile dans le ProcessViewhelper.