### PR TITLE
Decode accentued characters for text on li tag only

### DIFF
--- a/Classes/ViewHelpers/NoteBasPage/ProcessViewHelper.php
+++ b/Classes/ViewHelpers/NoteBasPage/ProcessViewHelper.php
@@ -78,7 +78,7 @@ class ProcessViewHelper extends AbstractViewHelper
         if (isset($matchesFootquote[0])) {
             foreach ($matchesFootquote[0] as $index => $wholeFootquote) {
                 $footquote = $matchesFootquote[2][$index];
-                $description = $matchesFootquote[1][$index];
+                $description = html_entity_decode($matchesFootquote[1][$index]);
 
                 $noteBasPageRepository->addNote($description);
 


### PR DESCRIPTION
Les accents se retrouvant dans les notes des balises LI étaient les seuls à ne pas être convertis. On a retravaillé l'ancienne ligne supprimée dans le dernier commit.